### PR TITLE
fix path to public key

### DIFF
--- a/lib/facter/public_key_comments.rb
+++ b/lib/facter/public_key_comments.rb
@@ -9,7 +9,7 @@ Facter.add(:public_key_comments) do
       keyfiles = Dir["#{user.dir}/.ssh/*.pub"]
       # Check each .pub file in ~/.ssh/ in turn
       keyfiles.each do |file|
-        contents = File.read("#{user.dir}/.ssh/#{file}")
+        contents = File.read("#{file}")
         contents.each_line do |line|
           comments << line.split(' ').last
         end


### PR DESCRIPTION
when fact is generated, the file path is incorrect, example:
/home/user/.ssh/home/user/.ssh/public_key